### PR TITLE
fix: update PKP integration status in landing page

### DIFF
--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -210,9 +210,9 @@ export const translations = {
       subtitle: "What's implemented, what's in progress, and what's planned",
       items: {
         pkpIntegration: {
-          status: 'In Progress',
+          status: 'Available (Optional)',
           title: 'Lit Protocol PKP Integration',
-          desc: 'PR #28 implements PKP-based signing. Currently under review. Until merged, Safe signatures are manual.',
+          desc: 'PKP-based automated signing is fully implemented and available. See docs/PKP_SETUP.md for setup instructions. Defaults to manual Safe multisig approval.',
         },
         networkSupport: {
           status: 'Implemented',
@@ -482,9 +482,9 @@ export const translations = {
       subtitle: '実装済み、進行中、計画中の機能',
       items: {
         pkpIntegration: {
-          status: '進行中',
+          status: '利用可能（オプション）',
           title: 'Lit Protocol PKP統合',
-          desc: 'PR #28がPKPベースの署名を実装。現在レビュー中。マージまでSafe署名は手動です。',
+          desc: 'PKPベースの自動署名は完全実装済みで利用可能です。セットアップ手順はdocs/PKP_SETUP.mdを参照してください。デフォルトは手動Safeマルチシグ承認です。',
         },
         networkSupport: {
           status: '実装済み',


### PR DESCRIPTION
## Summary

Removes outdated "PR #28" reference from landing page and accurately reflects the current PKP implementation status.

## Problem

The landing page showed:
- Status: "In Progress" / "進行中"
- Description: "PR #28 implements PKP-based signing. Currently under review. Until merged, Safe signatures are manual."

This was **incorrect** because:
- PKP integration is **fully implemented** (LitPKPSigner.ts, 428 lines)
- PKP_SETUP.md documentation exists
- All PKP tests passing
- No blocking PRs in review
- Feature is production-ready but optional

## Changes

### English (lines 212-216)
- ✅ Status: `"In Progress"` → `"Available (Optional)"`
- ✅ Description: Removed PR #28 reference
- ✅ Description: Added link to `docs/PKP_SETUP.md`
- ✅ Description: Clarified PKP is optional, defaults to manual Safe signing

### Japanese (lines 484-488)
- ✅ Status: `"進行中"` → `"利用可能（オプション）"`
- ✅ Description: PR #28への参照を削除
- ✅ Description: `docs/PKP_SETUP.md`へのリンクを追加
- ✅ Description: PKPはオプション機能で、デフォルトは手動Safe署名と明記

## Current Reality

PKP integration is **complete and usable**:

```typescript
// src/services/LitPKPSigner.ts (428 lines)
export class LitPKPSigner {
  async connect(): Promise<void> { /* ... */ }
  async signSafeTransaction(transaction, sessionSigs): Promise<ECDSASignature> { /* ... */ }
  async verifyConditions(conditions): Promise<boolean> { /* ... */ }
  getPKPEthAddress(): string { /* ... */ }
}
```

Documentation:
- ✅ `docs/PKP_SETUP.md` - Complete setup guide
- ✅ `src/services/__tests__/LitPKPSigner.test.ts` - Comprehensive tests
- ✅ `scripts/setup/mint-pkp.ts` - PKP minting script
- ✅ `scripts/setup/add-pkp-to-safe.ts` - Safe integration script

## Verification

- ✅ **textlint**: Passed
- ✅ **ESLint**: Passed
- ✅ **TypeScript**: Compiled successfully
- ✅ **Prettier**: All files formatted
- ✅ **Tests**: All 509 tests passing | 6 skipped
- ✅ **Coverage**: 99.93% (exceeds 99.9% threshold)
- ✅ **Build**: Next.js build successful

## Visual Changes

### Before
```
Status: In Progress
Lit Protocol PKP Integration
PR #28 implements PKP-based signing. Currently under review. 
Until merged, Safe signatures are manual.
```

### After
```
Status: Available (Optional)
Lit Protocol PKP Integration
PKP-based automated signing is fully implemented and available. 
See docs/PKP_SETUP.md for setup instructions. 
Defaults to manual Safe multisig approval.
```

## Why This Matters

Users were **confused** about PKP availability:
- "Is PKP ready to use?" → **Yes, fully ready**
- "Is manual signing temporary?" → **No, it's a valid permanent option**
- "What's PR #28?" → **Doesn't exist/outdated reference**

Now users clearly understand:
- PKP is **available now** (not "in progress")
- It's **optional** (not required)
- Setup instructions are **in docs/PKP_SETUP.md**
- Default behavior is **manual Safe signing** (safe and reliable)

## Files Changed

- `src/lib/i18n.ts` - Updated PKP status (EN & JA)

**Total**: 4 insertions, 4 deletions, 1 file changed

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PKP integration status to "Available (Optional)" with setup documentation references
  * Updated descriptions in English and Japanese versions to reflect PKP-based automated signing availability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->